### PR TITLE
Add Expo and Supabase deployment GitHub Actions

### DIFF
--- a/.github/workflows/expo-deploy.yml
+++ b/.github/workflows/expo-deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy Expo App
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --non-interactive
+
+      - name: Setup Expo CLI
+        uses: expo/expo-github-action@v8
+        with:
+          expo-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Publish update to Expo
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: expo publish --non-interactive

--- a/.github/workflows/supabase-edge-functions.yml
+++ b/.github/workflows/supabase-edge-functions.yml
@@ -1,0 +1,45 @@
+name: Deploy Supabase Edge Functions
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'supabase/functions/**'
+      - '.github/workflows/supabase-edge-functions.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+
+      - name: Authenticate with Supabase
+        run: supabase login --access-token "$SUPABASE_ACCESS_TOKEN"
+
+      - name: Deploy edge functions
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          functions=(supabase/functions/*)
+          if [ ${#functions[@]} -eq 0 ]; then
+            echo "No edge functions found to deploy."
+            exit 0
+          fi
+          for dir in "${functions[@]}"; do
+            if [ -d "$dir" ]; then
+              name="$(basename "$dir")"
+              echo "Deploying $name"
+              supabase functions deploy "$name" --project-ref "$SUPABASE_PROJECT_ID" --no-verify-jwt
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -68,3 +68,12 @@ Main screens:
 ![Login screen](https://i.imgur.com/ynyvDe5.png)
 
 ![Signup screen](https://i.imgur.com/ZtWEpnx.png)
+
+## Continuous deployment
+
+This starter includes GitHub Actions workflows to automate deployments:
+
+- **Deploy Expo App** (`.github/workflows/expo-deploy.yml`) publishes the app to Expo on pushes to `main`. Set the `EXPO_TOKEN` repository secret with a token generated from your Expo account so the workflow can authenticate before running `expo publish`.
+- **Deploy Supabase Edge Functions** (`.github/workflows/supabase-edge-functions.yml`) deploys any edge functions stored under `supabase/functions` using the Supabase CLI. Provide `SUPABASE_ACCESS_TOKEN` and `SUPABASE_PROJECT_ID` secrets so the workflow can log in and target the correct project.
+
+Both workflows can also be triggered manually from the GitHub Actions tab with the **Run workflow** button.


### PR DESCRIPTION
## Summary
- add a workflow that publishes the Expo application on pushes to main using an Expo token
- add a workflow that deploys Supabase edge functions with the Supabase CLI when functions change
- document the required secrets and new automation in the README

## Testing
- not run (automation configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e3c5888c84832dbad8cec1aa997239